### PR TITLE
feat: added the enrich function and basic modal logic formulas

### DIFF
--- a/lib/Defs.lhs
+++ b/lib/Defs.lhs
@@ -93,8 +93,6 @@ instance AntiSupportable KrM Team Form where
   (m,s) =| Or f g  = (m,s) =| f && (m,s) =| g
   (m,s) =| Dia f   = all (\w -> (m, rel m w) =| f) s
 
-  (=|) = uncurry antisupport
-
 -- In Aloni2024 it is indicated as []+
 enrich :: MForm -> Form
 enrich (MProp n) = Prop n

--- a/lib/Defs.lhs
+++ b/lib/Defs.lhs
@@ -168,12 +168,12 @@ u3 = Set.fromList [0..3]
 r3a, r3b, r3c :: World -> Set World
 r3a = const Set.empty
 
-r3b wpq = Set.fromList [wp, wpq]
-r3b w0  = Set.singleton wq
-r3b _   = Set.empty
+r3b 2 = Set.fromList [wp, wpq]
+r3b 3 = Set.singleton wq
+r3b _ = Set.empty
 
-r3c wpq = Set.fromList [wp, wq]
-r3c _   = Set.empty
+r3c 2 = Set.fromList [wp, wq]
+r3c _ = Set.empty
 
 v3 :: Proposition -> Set World
 v3 1 = Set.fromList [wp, wpq]

--- a/lib/Defs.lhs
+++ b/lib/Defs.lhs
@@ -135,6 +135,7 @@ Some example models.
 
 \begin{code}
 
+-- Aloni2024 - Figure 3c.
 figure3 :: KrM
 figure3 = KrM (Set.fromList [0, 1, 2, 3]) r v
   where r x = case x of


### PR DESCRIPTION
This PR adds two new things to the repo:

- a representation of basic modal logic formulas, useful since many of the results in the paper compare BSML to BML.
- an implementation of the `enrich :: MForm -> Form` operator, that in the paper is represented as `[]+`.

It also include the implementation for an example in Aloni2024 - Figure 3c.